### PR TITLE
Fix add item and list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 .idea/
 *.db
 config.py
+run.bat

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -6,6 +6,7 @@ from flask_login import (
     login_user,
     logout_user,
 )
+from sqlalchemy import func
 from webapp.forms import (
     AddIngredientForm,
     AddRecipeForm,
@@ -349,7 +350,7 @@ def create_app(database_uri=database_uri):
             new_shopping_list_name = form.name.data
 
             shopping_list_already_exists = ShoppingList.query.filter(
-                ShoppingList.name == new_shopping_list_name,
+                func.lower(ShoppingList.name) == func.lower(new_shopping_list_name),
                 ShoppingList.user_id == current_user.id,
             ).one_or_none()
 

--- a/webapp/static/main.js
+++ b/webapp/static/main.js
@@ -123,7 +123,7 @@ If these texts are equal to each other, function:
         $('label.item-name').each(function() {
             var item_name = $(this).text().trim();
 
-            if (item_name == new_item_name) {
+            if (item_name.toLowerCase() == new_item_name.toLowerCase()) {
 
                 let li = $(this).parents('li.shopping-list-item')
                 li.addClass('list-group-item-danger');


### PR DESCRIPTION
Добавить учёт регистра в валидацию при добавлении нового списка покупок и нового продукта в список покупок
Сделать так, чтобы пользователь не мог иметь списки покупок с одинаковым названием (независимо от регистра, т.е. "Продукты" и "продукты" считается одним и тем же списком. То же самое и для продуктов в списке покупок.
Названия списков покупок и продуктов теперь всегда добавляются в нижнем регистре, независимо от того, какой регистр использовал пользователь. Так, кажется, проще.