### PR TITLE
delete integrity attribute from bootstrap script

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -27,12 +27,11 @@
       href="https://getbootstrap.com/docs/5.3/examples/navbar-fixed/"
     />
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css" crossorigin="anonymous">
 
     <link
       href="https://getbootstrap.com/docs/5.3/dist/css/bootstrap.min.css"
       rel="stylesheet"
-      integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM"
       crossorigin="anonymous"
     />
 
@@ -291,7 +290,6 @@
     <main class="container-fluid">{% block content %}{% endblock %}</main>
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"
       crossorigin="anonymous"
     ></script>
   </body>


### PR DESCRIPTION
delete integrity attribute from bootstrap script in base.html to fix the problem "The resource has been blocked"